### PR TITLE
ci: cache dependencies, add tests in test dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,9 @@ jobs:
       - save_cache:
           key: deps-{{ checksum "poetry.lock" }}
           paths:
-            - ~/.local/bin/poetry
             - ~/.local/share/pypoetry
+            - ~/.local/bin/poetry
+            # The second path is a symlink and should be written afterwards
       - run:
           name: Run unit tests
           command: |
@@ -68,8 +69,9 @@ jobs:
       - save_cache:
           key: deps-{{ checksum "poetry.lock" }}
           paths:
-            - ~/.local/bin/poetry
             - ~/.local/share/pypoetry
+            - ~/.local/bin/poetry
+            # The second path is a symlink and should be loaded afterwards
       - run:
           name: Run integration tests
           parallel: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             cd ~/repo
             curl -sSL https://install.python-poetry.org | python3 -
-            ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
+            ln -sf ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
             ~/.local/bin/poetry install
       - save_cache:
           key: dev-deps-{{ checksum "poetry.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: |
             cd ~/repo
             shopt -s globstar
-            TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings --timings-type=classname)
             shopt -u globstar
             mkdir -p lug-unit-test-results
             ~/.local/bin/poetry run pytest -v -m "unit or unit_io" --durations=0 --junitxml=lug-unit-test-results/junit.xml $TESTFILES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: |
             cd ~/repo
             shopt -s globstar
-            TESTFILES=$(circleci tests glob test/test*.py test/**/test*.py | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "test/test*.py" "test/**/test*.py" | circleci tests split --split-by=timings --timings-type=filename)
             shopt -u globstar
             mkdir -p lug-unit-test-results
             ~/.local/bin/poetry run pytest -v -m "unit or unit_io" --durations=0 --junitxml=lug-unit-test-results/junit.xml $TESTFILES
@@ -80,7 +80,7 @@ jobs:
             cd ~/repo
             export DEPLOY_ENVIRONMENT=$([[ $CIRCLE_BRANCH = main ]] && echo production || echo staging)
             shopt -s globstar
-            TESTFILES=$(circleci tests glob test/test*.py test/**/test*.py | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "test/test*.py" "test/**/test*.py" | circleci tests split --split-by=timings --timings-type=filename)
             shopt -u globstar
             mkdir -p lug-integration-test-results
             ~/.local/bin/poetry run pytest -v -m integration --durations=0 --junitxml=lug-integration-test-results/junit.xml $TESTFILES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,19 @@ jobs:
     parallelism: 8
     steps:
       - checkout
+      - restore_cache:
+          key: deps-{{ checksum "poetry.lock" }}
+      - run:
+          name: Install dependencies
+          command: |
+            cd ~/repo
+            curl -sSL https://install.python-poetry.org | python3 -
+            ~/.local/bin/poetry install
+      - save_cache:
+          key: deps-{{ checksum "poetry.lock" }}
+          paths:
+            - ~/.local/bin/poetry
+            - ~/.local/share/pypoetry
       - run:
           name: Run unit tests
           command: |
@@ -31,8 +44,6 @@ jobs:
             shopt -s globstar
             TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings)
             shopt -u globstar
-            curl -sSL https://install.python-poetry.org | python3 -
-            ~/.local/bin/poetry install
             mkdir -p lug-unit-test-results
             ~/.local/bin/poetry run pytest -v -m "unit or unit_io" --durations=0 --junitxml=lug-unit-test-results/junit.xml $TESTFILES
       - store_test_results:
@@ -46,6 +57,19 @@ jobs:
     parallelism: 4
     steps:
       - checkout
+      - restore_cache:
+          key: deps-{{ checksum "poetry.lock" }}
+      - run:
+          name: Install dependencies
+          command: |
+            cd ~/repo
+            curl -sSL https://install.python-poetry.org | python3 -
+            ~/.local/bin/poetry install
+      - save_cache:
+          key: deps-{{ checksum "poetry.lock" }}
+          paths:
+            - ~/.local/bin/poetry
+            - ~/.local/share/pypoetry
       - run:
           name: Run integration tests
           parallel: true
@@ -55,8 +79,6 @@ jobs:
             shopt -s globstar
             TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings)
             shopt -u globstar
-            curl -sSL https://install.python-poetry.org | python3 -
-            ~/.local/bin/poetry install
             mkdir -p lug-integration-test-results
             ~/.local/bin/poetry run pytest -v -m integration --durations=0 --junitxml=lug-integration-test-results/junit.xml $TESTFILES
           no_output_timeout: 1h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum "poetry.lock" }}
+          key: dev-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -67,7 +67,7 @@ jobs:
             curl -sSL https://install.python-poetry.org | python3 -
             ~/.local/bin/poetry install
       - save_cache:
-          key: deps-{{ checksum "poetry.lock" }}
+          key: dev-deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: prv2-deps-{{ checksum "poetry.lock" }}
+          key: v1-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -34,7 +34,7 @@ jobs:
             ln -sf ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
             ~/.local/bin/poetry install
       - save_cache:
-          key: prv2-deps-{{ checksum "poetry.lock" }}
+          key: v1-deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin
@@ -44,7 +44,7 @@ jobs:
           command: |
             cd ~/repo
             shopt -s globstar
-            TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings --timings-type=classname)
+            TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings)
             shopt -u globstar
             mkdir -p lug-unit-test-results
             ~/.local/bin/poetry run pytest -v -m "unit or unit_io" --durations=0 --junitxml=lug-unit-test-results/junit.xml $TESTFILES
@@ -60,7 +60,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: prv2-deps-{{ checksum "poetry.lock" }}
+          key: v1-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -68,7 +68,7 @@ jobs:
             curl -sSL https://install.python-poetry.org | python3 -
             ~/.local/bin/poetry install
       - save_cache:
-          key: prv2-deps-{{ checksum "poetry.lock" }}
+          key: v1-deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
           command: |
             cd ~/repo
             curl -sSL https://install.python-poetry.org | python3 -
+            ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
             ~/.local/bin/poetry install
       - save_cache:
           key: deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
-            - ~/.local/bin/poetry
-            # The second path is a symlink and should be loaded afterwards
+            - ~/.local/bin
       - run:
           name: Run unit tests
           command: |
@@ -70,8 +70,7 @@ jobs:
           key: deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
-            - ~/.local/bin/poetry
-            # The second path is a symlink and should be loaded afterwards
+            - ~/.local/bin
       - run:
           name: Run integration tests
           parallel: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: |
             cd ~/repo
             shopt -s globstar
-            TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob test/test*.py test/**/test*.py | circleci tests split --split-by=timings)
             shopt -u globstar
             mkdir -p lug-unit-test-results
             ~/.local/bin/poetry run pytest -v -m "unit or unit_io" --durations=0 --junitxml=lug-unit-test-results/junit.xml $TESTFILES
@@ -80,7 +80,7 @@ jobs:
             cd ~/repo
             export DEPLOY_ENVIRONMENT=$([[ $CIRCLE_BRANCH = main ]] && echo production || echo staging)
             shopt -s globstar
-            TESTFILES=$(circleci tests glob test/**/test*.py | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob test/test*.py test/**/test*.py | circleci tests split --split-by=timings)
             shopt -u globstar
             mkdir -p lug-integration-test-results
             ~/.local/bin/poetry run pytest -v -m integration --durations=0 --junitxml=lug-integration-test-results/junit.xml $TESTFILES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin/poetry
-            # The second path is a symlink and should be written afterwards
+            # The second path is a symlink and should be loaded afterwards
       - run:
           name: Run unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum "poetry.lock" }}
+          key: dev-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -34,7 +34,7 @@ jobs:
             ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
             ~/.local/bin/poetry install
       - save_cache:
-          key: deps-{{ checksum "poetry.lock" }}
+          key: dev-deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dev-deps-{{ checksum "poetry.lock" }}
+          key: prv2-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -34,10 +34,11 @@ jobs:
             ln -sf ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
             ~/.local/bin/poetry install
       - save_cache:
-          key: dev-deps-{{ checksum "poetry.lock" }}
+          key: prv2-deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin
+            - ~/.cache/pypoetry
       - run:
           name: Run unit tests
           command: |
@@ -59,7 +60,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dev-deps-{{ checksum "poetry.lock" }}
+          key: prv2-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -67,10 +68,11 @@ jobs:
             curl -sSL https://install.python-poetry.org | python3 -
             ~/.local/bin/poetry install
       - save_cache:
-          key: dev-deps-{{ checksum "poetry.lock" }}
+          key: prv2-deps-{{ checksum "poetry.lock" }}
           paths:
             - ~/.local/share/pypoetry
             - ~/.local/bin
+            - ~/.cache/pypoetry
       - run:
           name: Run integration tests
           parallel: true


### PR DESCRIPTION
Caches package dependencies for CI, lowering the total unit test time to 2.5-3 mins.

Also adds tests in the main `tests` dir, which were previously skipped.