### PR TITLE
feat: add a better error if docker isn't running

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -849,6 +849,13 @@ files = [
     {file = "Pillow-9.4.0-1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:b8c2f6eb0df979ee99433d8b3f6d193d9590f735cf12274c108bd954e30ca858"},
     {file = "Pillow-9.4.0-1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b70756ec9417c34e097f987b4d8c510975216ad26ba6e57ccb53bc758f490dab"},
     {file = "Pillow-9.4.0-1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:43521ce2c4b865d385e78579a082b6ad1166ebed2b1a2293c3be1d68dd7ca3b9"},
+    {file = "Pillow-9.4.0-2-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:9d9a62576b68cd90f7075876f4e8444487db5eeea0e4df3ba298ee38a8d067b0"},
+    {file = "Pillow-9.4.0-2-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:87708d78a14d56a990fbf4f9cb350b7d89ee8988705e58e39bdf4d82c149210f"},
+    {file = "Pillow-9.4.0-2-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8a2b5874d17e72dfb80d917213abd55d7e1ed2479f38f001f264f7ce7bae757c"},
+    {file = "Pillow-9.4.0-2-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:83125753a60cfc8c412de5896d10a0a405e0bd88d0470ad82e0869ddf0cb3848"},
+    {file = "Pillow-9.4.0-2-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:9e5f94742033898bfe84c93c831a6f552bb629448d4072dd312306bab3bd96f1"},
+    {file = "Pillow-9.4.0-2-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:013016af6b3a12a2f40b704677f8b51f72cb007dac785a9933d5c86a72a7fe33"},
+    {file = "Pillow-9.4.0-2-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:99d92d148dd03fd19d16175b6d355cc1b01faf80dae93c6c3eb4163709edc0a9"},
     {file = "Pillow-9.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:2968c58feca624bb6c8502f9564dd187d0e1389964898f5e9e1fbc8533169157"},
     {file = "Pillow-9.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c5c1362c14aee73f50143d74389b2c158707b4abce2cb055b7ad37ce60738d47"},
     {file = "Pillow-9.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd752c5ff1b4a870b7661234694f24b1d2b9076b8bf337321a814c612665f343"},
@@ -1817,4 +1824,4 @@ reference = "pypi-public"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "0ad46f4b8b1b8e50191ef491f747a6d0eb7fb5e6251434685115b119527c022b"
+content-hash = "8c29de5d7de8abaabe5f1182b7a07906d830c370ff70f59251f7d61f5bffc991"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ toolchest-client = "^0.11.10"
 
 # Poetry 1.2 introduces a breaking change: this should eventually be refactored to "tool.poetry.group.dev.dependencies"
 # For now, all CircleCI Python orbs still have Poetry 1.1, which doesn't support the "group" notation
+importlib-metadata = "4.13"
 [tool.poetry.dev-dependencies]
 mkdocs-material = "^8.4.2"
 pytest = "^7.1.3"

--- a/src/lug/lug.py
+++ b/src/lug/lug.py
@@ -1,7 +1,9 @@
 import base64
 import functools
 import glob
-from importlib.metadata import packages_distributions, version
+
+from docker.errors import DockerException, APIError
+from importlib_metadata import packages_distributions, version
 import inspect
 import os
 import shutil
@@ -525,8 +527,13 @@ def run(image=None, mount=os.getcwd(), tmp_dir=tempfile.gettempdir(), docker_she
                 else:
                     client, user_docker = None, None
                     if image:
-                        client = docker.from_env()
-
+                        try:
+                            client = docker.from_env()
+                        except (APIError, DockerException):
+                            raise EnvironmentError(
+                                'Unable to connect to Docker. Make sure you have Docker installed and that it is '
+                                'currently running.'
+                            )
                         # Get or pull the user Docker image from local/remote
                         user_docker = DockerContainer(
                             docker_client=client,


### PR DESCRIPTION
Also switches to `importlib_metadata` to resolve import errors depending on python version.

Error is the same one for other docker lug issues.